### PR TITLE
Handle chat API errors in UI

### DIFF
--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -20,7 +20,19 @@ export default function Home() {
   // Boot the conversation
   useEffect(() => {
     (async () => {
-      const data = await callChatAPI("", conversationId ?? "");
+      const { data, error: err } = await callChatAPI("", conversationId ?? "");
+      if (!data) {
+        console.error("Error booting conversation", err);
+        setMessages([
+          {
+            id: Date.now().toString() + Math.random().toString(),
+            content: err ?? "Error contacting server.",
+            role: "assistant",
+            timestamp: new Date(),
+          },
+        ]);
+        return;
+      }
       setConversationId(data.conversation_id);
       setCurrentAgent(data.current_agent);
       setContext(data.context);
@@ -57,7 +69,21 @@ export default function Home() {
     setMessages((prev) => [...prev, userMsg]);
     setIsLoading(true);
 
-    const data = await callChatAPI(content, conversationId ?? "");
+    const { data, error: err } = await callChatAPI(content, conversationId ?? "");
+    if (!data) {
+      console.error("Error sending message", err);
+      setIsLoading(false);
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now().toString() + Math.random().toString(),
+          content: err ?? "Error contacting server.",
+          role: "assistant",
+          timestamp: new Date(),
+        },
+      ]);
+      return;
+    }
 
     if (!conversationId) setConversationId(data.conversation_id);
     setCurrentAgent(data.current_agent);

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -6,10 +6,14 @@ export async function callChatAPI(message: string, conversationId: string) {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ conversation_id: conversationId, message }),
     });
-    if (!res.ok) throw new Error(`Chat API error: ${res.status}`);
-    return res.json();
+    if (!res.ok) {
+      return { error: `Chat API error: ${res.status}` };
+    }
+    const data = await res.json();
+    return { data };
   } catch (err) {
     console.error("Error sending message:", err);
-    return null;
+    const message = err instanceof Error ? err.message : String(err);
+    return { error: message };
   }
 }


### PR DESCRIPTION
## Summary
- make `callChatAPI` return `{data, error}` instead of `null`
- handle error cases in the home page boot logic
- show a user-facing error message if the chat API fails

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855797174d8832a89c541a7f08dacf3